### PR TITLE
Add a timeout configuration setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ config = ArchivesSpace::Configuration.new({
   page_size: 50,
   throttle: 0,
   verify_ssl: false,
+  timeout: 60
 })
 
 client = ArchivesSpace::Client.new(config).login
@@ -131,6 +132,7 @@ Create an `~/.asclientrc` file with a json version of the client configuration:
   "password": "123456",
   "page_size": 50,
   "throttle": 0,
+  "timeout": 60,
   "verify_ssl": false
 }
 ```

--- a/lib/archivesspace/client/configuration.rb
+++ b/lib/archivesspace/client/configuration.rb
@@ -11,7 +11,8 @@ module ArchivesSpace
         password: "admin",
         page_size: 50,
         throttle: 0,
-        verify_ssl: true
+        verify_ssl: true,
+        timeout: 60
       }
     end
 

--- a/lib/archivesspace/client/request.rb
+++ b/lib/archivesspace/client/request.rb
@@ -29,6 +29,7 @@ module ArchivesSpace
       @options[:headers] =
         options[:headers] ? default_headers(@method).merge(options[:headers]) : default_headers(@method)
       @options[:verify] = config.verify_ssl
+      @options[:timeout] = config.timeout
       @options[:query] = {} unless options.key? :query
 
       self.class.debug_output($stdout) if @config.debug


### PR DESCRIPTION
The API we're connecting to often takes over a minute to respond; it would be nice if the client could be instructed to wait longer before giving up.