### PR TITLE
Consistent console config; README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ client = ArchivesSpace::Client.new.login
 
 ```ruby
 config = ArchivesSpace::Configuration.new({
-  base_uri: "https://archives.university.edu/api",
+  base_uri: "https://archives.university.edu/staff/api",
   base_repo: "",
   username: "admin",
   password: "123456",
@@ -128,7 +128,7 @@ Create an `~/.asclientrc` file with a json version of the client configuration:
 
 ```json
 {
-  "base_uri": "https://archives.university.edu/api",
+  "base_uri": "https://archives.university.edu/staff/api",
   "base_repo": "",
   "username": "admin",
   "password": "123456",

--- a/bin/console
+++ b/bin/console
@@ -5,15 +5,7 @@ require "bundler/setup"
 require "archivesspace/client"
 
 config = ArchivesSpace::Configuration.new(
-  {
-    base_uri: "https://test.archivesspace.org/staff/api",
-    base_repo: "",
-    username: "admin",
-    password: "admin",
-    page_size: 50,
-    throttle: 0,
-    verify_ssl: false
-  }
+  ArchivesSpace::Client::CLI.find_config
 )
 @client = ArchivesSpace::Client.new(config).login
 


### PR DESCRIPTION
- Make `bin/console` use the same config as running a CLI command would
- Update custom config examples in README to include the `staff` segment in the base_uri