### PR TITLE
Add structure and TOC to README; clarify config options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1

--- a/archivesspace-client.gemspec
+++ b/archivesspace-client.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httparty", "~> 0.14"
   spec.add_dependency "json", "~> 2.0"
   spec.add_dependency "nokogiri", "~> 1.10"
-  spec.add_dependency "jbuilder", "~> 2.11.5"
+  spec.add_dependency "jbuilder", "~> 2.12"
 end


### PR DESCRIPTION
This is just README updates, except for the jbuilder version bump, which was required to make tests pass in CI. 

active_support 8 was being loaded (which no longer has a ProxyObject class), but [jbuilder pre-2.12.0 relied on ProxyObject](https://github.com/rails/jbuilder/releases/tag/v2.12.0).