### PR TITLE
Allow use of dry-cli 1.x

### DIFF
--- a/archivesspace-client.gemspec
+++ b/archivesspace-client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr", "~> 6.3"
   spec.add_development_dependency "webmock", "~> 3.24"
 
-  spec.add_dependency "dry-cli", "~> 0.7"
+  spec.add_dependency "dry-cli", "< 2.0"
   spec.add_dependency "httparty", "~> 0.14"
   spec.add_dependency "json", "~> 2.0"
   spec.add_dependency "jbuilder", "~> 2.12"


### PR DESCRIPTION
Thanks so much for the Aspace client!

The Aspace Client currently has the version of dry-cli set to ~> 0.7. Version 1.0.0 of dry-cli was released in 2022, with no breaking changes from the pre-release versions (see https://github.com/dry-rb/dry-cli/releases/tag/v1.0.0).

I'd like to use both the Aspace Client and a newer version of the dry-cli gem.  Would you consider relaxing the dry-cli version pin to allow 0.x and 1.x?  Thanks for your consideration!